### PR TITLE
Add Sentry observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Optional — leave empty for local dev and tests. CI injects the real value from GitHub secrets.
+VITE_SENTRY_DSN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - run: yarn build
+        env:
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
 
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/master'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fortawesome/fontawesome-svg-core": "^7.3.1",
     "@fortawesome/free-brands-svg-icons": "^7.3.1",
     "@fortawesome/react-fontawesome": "^3.5.0",
+    "@sentry/react": "10.72.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "styled-components": "^6.5.3"

--- a/specs/01-observability.md
+++ b/specs/01-observability.md
@@ -1,0 +1,21 @@
+# Observability
+
+Production monitoring for [oliveiraswell.github.io](https://oliveiraswell.github.io).
+
+## Sentry (errors)
+
+- **Project:** `wellington-oliveira/wellington-oliveira`
+- **Client:** `@sentry/react`, initialized in `src/main.jsx` when `VITE_SENTRY_DSN` is set
+- **CI:** GitHub Actions passes `secrets.VITE_SENTRY_DSN` at build time so the DSN is baked into the production bundle without committing it
+- **Local:** copy `.env.example` to `.env.local` and set `VITE_SENTRY_DSN` if you need to test error reporting locally
+
+## Google Analytics 4 (traffic)
+
+- **Measurement ID:** `G-XG7QCYN9FM`
+- **Integration:** gtag snippet in `index.html` (pageview on load; no React routing)
+- Unchanged by Sentry work — both run independently in production
+
+## UptimeRobot (availability)
+
+- External HTTP monitor on the live site URL
+- Alerts when the homepage is unreachable; complements Sentry (runtime errors) and GA (usage)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,16 @@
+import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App/App";
+
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
+
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: import.meta.env.MODE,
+  });
+}
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/src/main.test.jsx
+++ b/src/main.test.jsx
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+const sentryInit = vi.fn();
+
+vi.mock("@sentry/react", () => ({
+  init: sentryInit,
+}));
+
+vi.mock("react-dom/client", () => ({
+  createRoot: vi.fn(() => ({ render: vi.fn() })),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  sentryInit.mockClear();
+  document.body.innerHTML = '<div id="root"></div>';
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test("renders the app without initializing Sentry when VITE_SENTRY_DSN is unset", async () => {
+  vi.stubEnv("VITE_SENTRY_DSN", "");
+
+  await import("./main.jsx");
+
+  expect(sentryInit).not.toHaveBeenCalled();
+});
+
+test("initializes Sentry when VITE_SENTRY_DSN is set", async () => {
+  const dsn = "https://examplePublicKey@o0.ingest.sentry.io/0";
+  vi.stubEnv("VITE_SENTRY_DSN", dsn);
+
+  await import("./main.jsx");
+
+  expect(sentryInit).toHaveBeenCalledWith(
+    expect.objectContaining({ dsn, environment: expect.any(String) }),
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,6 +456,70 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
   integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
+"@sentry/browser-utils@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser-utils/-/browser-utils-10.72.0.tgz#0037942e3f41ad06e29dd29f1363b40a26c59436"
+  integrity sha512-aZyogxXnNgDRupNscB8VEZdJbhbIk0+LiXrg5Fl82foGlcc5I22GdxORSb/JHwkeMFttZmvh1/OMwSPzAmE94Q==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.72.0"
+
+"@sentry/browser@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.72.0.tgz#d16cb66722d2493176cb25320aa57409d9ae4c8d"
+  integrity sha512-pbXHaovq/rRO5wsHz6Yey6SBPJLrbi7kCaYlSr6+v4bB4UoIL5dFB65BcQ7XD3BzZDNNvl6jTe68a1/sUMb5oA==
+  dependencies:
+    "@sentry/browser-utils" "10.72.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.72.0"
+    "@sentry/feedback" "10.72.0"
+    "@sentry/replay" "10.72.0"
+    "@sentry/replay-canvas" "10.72.0"
+
+"@sentry/conventions@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
+  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+
+"@sentry/core@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.72.0.tgz#0b6aa84b75199f6a90ca7b215a569a5527d55fe7"
+  integrity sha512-UJMHZfbjP4qk+g4AQhZmzosMdICC2D9p0/hLrm1LofPsp+WBfcSnv9jsY1a9TfmpS4WCAmTx8nANYTIXifcBjA==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+
+"@sentry/feedback@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/feedback/-/feedback-10.72.0.tgz#4184a8012307813c2ac4883886074c0287edf4f3"
+  integrity sha512-UPCABAD5WkOIg8XfyH58B5hsP19RGBbMXmiu7k7yQ0kFr/QIsn1tO2ts5w8ek5tIuTdAaeK3L+tinnCRh2STbg==
+  dependencies:
+    "@sentry/core" "10.72.0"
+
+"@sentry/react@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-10.72.0.tgz#57048591a2c0459de5c82d6e563b0492cb9068f2"
+  integrity sha512-I+/Wq2duluHIGoCVbtm2FsC4kp160hNmKVFlCVa/UsutsuEbZAcFC1GI8Zzg/uUWbR7x/LhH7OqP9jdfwJsm4Q==
+  dependencies:
+    "@sentry/browser" "10.72.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.72.0"
+
+"@sentry/replay-canvas@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay-canvas/-/replay-canvas-10.72.0.tgz#a8a53c8d257019f36fc289f3e798628b90ec19dc"
+  integrity sha512-RdNCbuQ1TBsyCrkHDBPTukQ3gtm8chXi0ldiJSiNUduPGCoKet9L1JocTqJ2gMguV+bOK+QLMvFnBCDbdcSg6A==
+  dependencies:
+    "@sentry/core" "10.72.0"
+    "@sentry/replay" "10.72.0"
+
+"@sentry/replay@10.72.0":
+  version "10.72.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-10.72.0.tgz#07753d8ce1f76f2aec2f8c91422ef884d3397222"
+  integrity sha512-DiUnhALGvEzaF7bSuRnr/Xftfh4eYZHQ9kwb+CRIDbJ0R2beetHH7vzE8vDe3pFMd8TWAuLkdNLMTC2ic9xfnA==
+  dependencies:
+    "@sentry/browser-utils" "10.72.0"
+    "@sentry/core" "10.72.0"
+
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"


### PR DESCRIPTION
## Summary
- Add `@sentry/react@10.72.0` and initialize in `src/main.jsx` only when `VITE_SENTRY_DSN` is set
- Pass `VITE_SENTRY_DSN` from GitHub secrets during CI production build
- Document Sentry alongside existing GA4 and UptimeRobot in `specs/01-observability.md`
- Add `.env.example` and tests confirming the app renders without Sentry configured

## Test plan
- [x] `yarn test` — 15 tests pass, including Sentry optional init
- [x] `yarn lint`
- [x] `yarn build` without DSN succeeds
- [ ] Merge and verify Sentry receives events from production after deploy


Made with [Cursor](https://cursor.com)